### PR TITLE
Update loot spec when changing active spec

### DIFF
--- a/Interface/AddOns/oUF_Neav/modules/oUF_LootSpecIndicator/lootspecindicator.lua
+++ b/Interface/AddOns/oUF_Neav/modules/oUF_LootSpecIndicator/lootspecindicator.lua
@@ -96,6 +96,7 @@ local function Enable(self)
         if self.unit == "player" then
             self:RegisterEvent("PLAYER_LOGIN", Path, true)
             self:RegisterEvent("PLAYER_LOOT_SPEC_UPDATED", Path, true)
+            self:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED", Path, true)
         end
 
         return true


### PR DESCRIPTION
At the moment the loot spec icon is only updated if you actively change the current loot spec (or if you reload/login) by right-clicking the player frame. However the default value (`0`) changes the loot spec
automatically based on the currently active spec. But changing spec doesn't trigger the `PLAYER_LOOT_SPEC_UPDATED` event (at least not for DPS classes).

But by also updating on `ACTIVE_TALENT_GROUP_CHANGED` you get the desired behaviour when using the default loot spec.